### PR TITLE
feat: add multi-git-status package for monitoring multiple git repos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
       customOverlay = final: prev: {
         gwq = final.callPackage ./packages/gwq.nix { };
         claude-code-acp = final.callPackage ./packages/claude-code-acp.nix { };
+        multi-git-status = final.callPackage ./packages/multi-git-status.nix { };
       };
 
       # home-manager 設定のパス

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -29,6 +29,7 @@
     gh
     ghq
     gwq # Git worktree マネージャ
+    multi-git-status # 複数 Git リポジトリの状態表示 (mgitstatus)
     tig
     jujutsu # Git 互換 VCS (jj コマンド)
     # lazygit は programs.lazygit で管理

--- a/packages/multi-git-status.nix
+++ b/packages/multi-git-status.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  git,
+  coreutils,
+  findutils,
+  gnugrep,
+  gnused,
+  gawk,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "multi-git-status";
+  version = "2.3";
+
+  src = fetchFromGitHub {
+    owner = "fboender";
+    repo = "multi-git-status";
+    rev = version;
+    hash = "sha256-DToyP6TD9up0k2/skMW3el6hNvKD+c8q2zWpk0QZGRA=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 mgitstatus "$out/bin/mgitstatus"
+    ln -s "$out/bin/mgitstatus" "$out/bin/multi-git-status"
+    install -Dm644 mgitstatus.1 "$out/share/man/man1/mgitstatus.1"
+    wrapProgram "$out/bin/mgitstatus" \
+      --prefix PATH : ${lib.makeBinPath [
+        git
+        coreutils
+        findutils
+        gnugrep
+        gnused
+        gawk
+      ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Show uncommitted, untracked, and unpushed changes in multiple Git repositories";
+    homepage = "https://github.com/fboender/multi-git-status";
+    license = licenses.mit;
+    mainProgram = "mgitstatus";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
Add custom Nix package for mgitstatus tool that shows uncommitted, untracked, and unpushed changes across multiple Git repositories. Include package definition, flake overlay, and home-manager integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new third-party CLI package and exposes it via overlay/Home Manager without changing existing system logic.
> 
> **Overview**
> Adds a new custom Nix package `multi-git-status` (mgitstatus) fetched from GitHub and wrapped to include required CLI dependencies on `PATH`, including an alias binary and manpage install.
> 
> Integrates the package into the flake `customOverlay` and includes it in the shared `modules/common.nix` `home.packages`, making the tool available across configured hosts/users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ad9b8da43183f1a934df98791c6ff1f75227bed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->