### PR TITLE
ci: add nix-flake-update workflow

### DIFF
--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -1,0 +1,60 @@
+name: nix-flake-update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: nix-flake-update
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Update flake inputs
+        run: make update
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git User
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit changes
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git add -A
+          git commit -m "chore(nix): update flake inputs"
+
+      - name: Push changes
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          PAT: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          git remote set-url origin https://x-access-token:${PAT}@github.com/${{ github.repository }}.git
+          git push origin HEAD:${GITHUB_REF_NAME}


### PR DESCRIPTION
## Summary

- `make update`（`nix flake update`）を毎日実行し、変更があれば自動でコミット・プッシュするGitHub Actionsワークフローを追加
- `mise-upgrade.yml` と同じ構造・パターンを踏襲
- Nixインストールは `nix-check.yml` と同じ `DeterminateSystems/nix-installer-action@main` を使用

## Test plan

- [ ] `workflow_dispatch` で手動実行して動作確認
- [ ] flake.lockに変更がない場合にコミットがスキップされることを確認
- [ ] flake.lockに変更がある場合に自動コミット・プッシュされることを確認

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a scheduled workflow that commits and pushes changes using a repository write token; misconfiguration could cause unwanted automated commits or token exposure via workflow settings.
> 
> **Overview**
> Adds a new GitHub Actions workflow `nix-flake-update.yml` that runs daily (and via manual dispatch) to execute `make update` (`nix flake update`).
> 
> If the update changes the repo (e.g., `flake.lock`), the workflow auto-configures a bot git identity, commits with message `chore(nix): update flake inputs`, and pushes back to the current branch using `secrets.PERSONAL_ACCESS_TOKEN` with `contents: write` permission and concurrency control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8e80a91edc47726222e1f33980281cf0de1d8d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->