### PR TITLE
fix(ci): repair flake check evaluation

### DIFF
--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -6,8 +6,12 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   flake-check:

--- a/flake.nix
+++ b/flake.nix
@@ -79,19 +79,19 @@
       # 共通の home-manager モジュール
       commonHomeModules = [
         catppuccin.homeModules.catppuccin
-        "${hmConfigPath}/overrides/clawdbot.nix"
-        "${hmConfigPath}/dotfiles.nix"
-        "${hmConfigPath}/common.nix"
+        (hmConfigPath + "/overrides/clawdbot.nix")
+        (hmConfigPath + "/dotfiles.nix")
+        (hmConfigPath + "/common.nix")
       ];
 
       # macOS 用 home-manager 設定
       darwinHomeModules = commonHomeModules ++ [
-        "${hmConfigPath}/darwin.nix"
+        (hmConfigPath + "/darwin.nix")
       ];
 
       # Linux 用 home-manager 設定
       linuxHomeModules = commonHomeModules ++ [
-        "${hmConfigPath}/linux.nix"
+        (hmConfigPath + "/linux.nix")
       ];
 
       # home-manager 設定を生成する関数


### PR DESCRIPTION
## Summary
- use path concatenation for Home Manager module imports in `flake.nix`
- add `id-token: write` to the nix-check workflow for Determinate/FlakeHub OIDC
- force GitHub JavaScript actions onto Node 24 to address the deprecation warning

## Verification
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI/workflow permission tweaks and Nix path import adjustments; main risk is CI auth/caching behavior changes due to enabling OIDC token issuance.
> 
> **Overview**
> Fixes `flake.nix` home-manager module imports by switching from string interpolation to explicit path concatenation (e.g., `(hmConfigPath + "/common.nix")`) to avoid flake evaluation issues.
> 
> Updates the `nix-check` GitHub Actions workflow to **enable OIDC** (`permissions: id-token: write`) for Determinate/FlakeHub integrations and forces JavaScript actions to run on **Node 24** via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to silence deprecation warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2656bb42457d0fb4e046a914e30ca8497634bd24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->