### PR TITLE
launcher が未導入 python 解決に巻き込まれる問題を修正

### DIFF
--- a/scripts/run-claude-corporate.sh
+++ b/scripts/run-claude-corporate.sh
@@ -4,19 +4,4 @@ export CLAUDE_IDENTITY="corporate"
 export CLAUDE_CONFIG_DIR="${HOME}/.claude"
 unset CLAUDE_CODE_OAUTH_TOKEN
 
-# --happy オプションを検出して Happy Coder モードで起動
-use_happy=false
-args=()
-for arg in "$@"; do
-  if [[ "$arg" == "--happy" ]]; then
-    use_happy=true
-  else
-    args+=("$arg")
-  fi
-done
-
-if $use_happy; then
-  exec "$(mise which happy)" --permission-mode bypassPermissions "${args[@]}"
-else
-  exec "$(mise which claude)" --dangerously-skip-permissions "${args[@]}"
-fi
+exec "$(mise which claude)" --dangerously-skip-permissions "$@"

--- a/scripts/run-claude-corporate.sh
+++ b/scripts/run-claude-corporate.sh
@@ -4,4 +4,4 @@ export CLAUDE_IDENTITY="corporate"
 export CLAUDE_CONFIG_DIR="${HOME}/.claude"
 unset CLAUDE_CODE_OAUTH_TOKEN
 
-exec "$(mise which claude)" --dangerously-skip-permissions "$@"
+exec mise exec claude -- claude --dangerously-skip-permissions "$@"

--- a/scripts/run-claude-corporate.sh
+++ b/scripts/run-claude-corporate.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
 
+export CLAUDE_IDENTITY="corporate"
 export CLAUDE_CONFIG_DIR="${HOME}/.claude"
 unset CLAUDE_CODE_OAUTH_TOKEN
 
-exec mise exec -- claude --dangerously-skip-permissions "${args[@]}"
+# --happy オプションを検出して Happy Coder モードで起動
+use_happy=false
+args=()
+for arg in "$@"; do
+  if [[ "$arg" == "--happy" ]]; then
+    use_happy=true
+  else
+    args+=("$arg")
+  fi
+done
 
+if $use_happy; then
+  exec "$(mise which happy)" --permission-mode bypassPermissions "${args[@]}"
+else
+  exec "$(mise which claude)" --dangerously-skip-permissions "${args[@]}"
+fi

--- a/scripts/run-claude-personal.sh
+++ b/scripts/run-claude-personal.sh
@@ -4,4 +4,4 @@ export CLAUDE_IDENTITY="personal"
 export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
 unset CLAUDE_CODE_OAUTH_TOKEN
 
-exec "$(mise which claude)" --dangerously-skip-permissions "$@"
+exec mise exec claude -- claude --dangerously-skip-permissions "$@"

--- a/scripts/run-claude-personal.sh
+++ b/scripts/run-claude-personal.sh
@@ -4,4 +4,19 @@ export CLAUDE_IDENTITY="personal"
 export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
 unset CLAUDE_CODE_OAUTH_TOKEN
 
-exec mise exec -- claude --dangerously-skip-permissions "${args[@]}"
+# --happy オプションを検出して Happy Coder モードで起動
+use_happy=false
+args=()
+for arg in "$@"; do
+  if [[ "$arg" == "--happy" ]]; then
+    use_happy=true
+  else
+    args+=("$arg")
+  fi
+done
+
+if $use_happy; then
+  exec "$(mise which happy)" --permission-mode bypassPermissions "${args[@]}"
+else
+  exec "$(mise which claude)" --dangerously-skip-permissions "${args[@]}"
+fi

--- a/scripts/run-claude-personal.sh
+++ b/scripts/run-claude-personal.sh
@@ -4,19 +4,4 @@ export CLAUDE_IDENTITY="personal"
 export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
 unset CLAUDE_CODE_OAUTH_TOKEN
 
-# --happy オプションを検出して Happy Coder モードで起動
-use_happy=false
-args=()
-for arg in "$@"; do
-  if [[ "$arg" == "--happy" ]]; then
-    use_happy=true
-  else
-    args+=("$arg")
-  fi
-done
-
-if $use_happy; then
-  exec "$(mise which happy)" --permission-mode bypassPermissions "${args[@]}"
-else
-  exec "$(mise which claude)" --dangerously-skip-permissions "${args[@]}"
-fi
+exec "$(mise which claude)" --dangerously-skip-permissions "$@"

--- a/scripts/run-codex-corporate.sh
+++ b/scripts/run-codex-corporate.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 export CODEX_HOME="${HOME}/.codex"
-exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"
+exec "$(mise which codex)" --dangerously-bypass-approvals-and-sandbox "$@"

--- a/scripts/run-codex-corporate.sh
+++ b/scripts/run-codex-corporate.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 export CODEX_HOME="${HOME}/.codex"
-exec "$(mise which codex)" --dangerously-bypass-approvals-and-sandbox "$@"
+exec mise exec codex -- codex --dangerously-bypass-approvals-and-sandbox "$@"

--- a/scripts/run-codex-personal.sh
+++ b/scripts/run-codex-personal.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 export CODEX_HOME="${HOME}/.codex-personal"
-exec "$(mise which codex)" --dangerously-bypass-approvals-and-sandbox "$@"
+exec mise exec codex -- codex --dangerously-bypass-approvals-and-sandbox "$@"

--- a/scripts/run-codex-personal.sh
+++ b/scripts/run-codex-personal.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 export CODEX_HOME="${HOME}/.codex-personal"
-exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"
+exec "$(mise which codex)" --dangerously-bypass-approvals-and-sandbox "$@"


### PR DESCRIPTION
## 概要
- `mise exec -- <cmd>` で launcher を起動していた経路をやめ、`mise which` で解決した実体バイナリを直接起動するように変更
- `claude` launcher に `--happy` 分岐と `CLAUDE_IDENTITY` の設定を揃えた
- `codex` launcher も同様に未導入の `python@3.14.6` を解決しに行かないようにした

## 背景
別ディレクトリで `run-claude-corporate.sh` などを起動すると、`claude`/`codex` 自体は導入済みでも `mise` が global tools 全体を解決し、未導入の `python@3.14.6` の source build に入って失敗していたためです。

## 影響
- launcher が Python 3.14.6 のインストール失敗に巻き込まれず起動できるようになります
- `claude --version` / `codex --version` のような単純な起動でも不要な warning を出さなくなります

## 確認
- `bash -n scripts/run-claude-corporate.sh scripts/run-claude-personal.sh scripts/run-codex-corporate.sh scripts/run-codex-personal.sh`
- `./scripts/run-claude-corporate.sh --version`
- `./scripts/run-claude-personal.sh --version`
- `./scripts/run-codex-corporate.sh --version`
- `./scripts/run-codex-personal.sh --version`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell launcher-only changes; behavior is limited to how binaries are invoked via mise, with no new security or data-handling logic.
> 
> **Overview**
> Updates the **Claude** and **Codex** wrapper scripts so `mise` runs only the named tool (`mise exec claude` / `mise exec codex`) instead of `mise exec -- …`, avoiding resolution of unrelated global tools (e.g. missing `python@3.14.6`) when launching from arbitrary directories.
> 
> The corporate Claude launcher now sets **`CLAUDE_IDENTITY=corporate`**, matching the personal script. Claude wrappers also forward arguments with **`"$@"`** instead of a separate `args` array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c9c0cb3f4494c019766e2dfe21c24ce5b115ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->