### PR TITLE
fix(mise): use precompiled-only python and pin back to 3.14.5

### DIFF
--- a/config/mise/mise.toml
+++ b/config/mise/mise.toml
@@ -1,6 +1,10 @@
 [settings]
 activate_aggressive = true
 ruby.compile = false
+# python はプリコンパイル版のみ使う。CPython リリース直後はプリコンパイル版が
+# 未公開のことがあり、ソースビルドへのフォールバックは macOS (Nix 環境) で
+# 失敗する。false にするとバンプ対象もプリコンパイル版の一覧に限定される。
+python.compile = false
 # rust は手動 rustup で管理する。mise が rust-toolchain.toml を自動検出して
 # 既定 toolchain (stable) の bin を PATH に注入し、rustup proxy をバイパスする
 # 不具合があるため、rust プラグイン自体を無効化する
@@ -14,7 +18,7 @@ credential_command = "gh auth token"
 [tools]
 java = "temurin-26.0.1"
 node = "26"
-python = "3.14.6"
+python = "3.14.5"
 ruby = "4.0"
 claude = "2.1.173"
 codex = "0.138.0"


### PR DESCRIPTION
## 問題

シェル起動のたびに以下の警告が出る:

```
mise WARN  missing: python@3.14.6
```

## 原因

1. 時間毎の `mise-upgrade` ワークフロー（`--minimum-release-age 0s`）が、CPython 3.14.6 リリース直後に `python = "3.14.6"` へバンプした
2. しかし python-build-standalone（astral）のプリコンパイル版 3.14.6 は **まだ未公開**
3. macOS 側で `mise install python@3.14.6` はソースビルド（pyenv python-build）にフォールバックし、OpenSSL ビルド中の `zlib.h` 欠如で失敗
4. 結果、グローバル設定が要求するバージョンが永遠に missing のまま警告が出続ける

## 修正

- `python = "3.14.5"` に戻す（プリコンパイル版が存在する最新）
- `python.compile = false` を追加（既存の `ruby.compile = false` と同様）

`python.compile = false` にすると `mise upgrade --bump` の候補がプリコンパイル版の一覧に限定されることを検証済み:

```
$ MISE_PYTHON_COMPILE=0 mise ls-remote python | tail -2   # → 3.14.5 まで
$ MISE_PYTHON_COMPILE=1 mise ls-remote python | tail -1   # → 3.14.6
```

隔離環境で `mise upgrade --yes --bump --minimum-release-age 0s` を実行し、`python = "3.14.5"` のまま「All tools are up to date」となることを確認。プリコンパイル版 3.14.6 が公開されれば、ワークフローが通常どおり自動バンプする（自己回復）。

## マージ後の作業

ローカルで `make apply` を実行すると `~/.config/mise/config.toml` が更新され、警告が消える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain config only; no runtime app or security logic changes.
> 
> **Overview**
> **Pins Python back to `3.14.5`** and sets **`python.compile = false`** in `config/mise/mise.toml`, mirroring the existing `ruby.compile = false` pattern.
> 
> The pin avoids a broken state where auto-bump had moved to **3.14.6** while precompiled builds were not yet available, leaving `mise` reporting `missing: python@3.14.6` and macOS falling back to a source build that fails in Nix-like environments. With compile disabled, **`mise upgrade --bump`** only considers versions that have precompiled artifacts, so the hourly upgrade workflow should not advance Python past what can actually be installed until 3.14.6 prebuilds ship.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5546e180759d555f3a524113c5e6382bb9060225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->