### PR TITLE
[codex] Disable Homebrew activation upgrades

### DIFF
--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
 {
   # ============================================================
@@ -12,16 +12,9 @@
       # "zap" は Brewfile に無いパッケージを全削除するため危険
       # "none" = 何もしない, "uninstall" = formulae のみ削除, "zap" = 全削除
       cleanup = lib.mkDefault "none";
-      upgrade = true;
-      extraFlags =
-        # Homebrew Bundle 4.6+ では --cleanup に --force-cleanup が必須。
-        lib.optional (
-          builtins.elem config.homebrew.onActivation.cleanup [
-            "uninstall"
-            "zap"
-          ]
-        ) "--force-cleanup"
-        ++ [ "--verbose" ];
+      # GUI cask の更新は .app の置き換えで macOS 権限状態が揺れやすいため、make apply では行わない。
+      upgrade = false;
+      extraFlags = [ "--verbose" ];
     };
 
     # Homebrew taps


### PR DESCRIPTION
## Summary

- Disable Homebrew upgrades during nix-darwin activation.
- Keep Homebrew cleanup behavior unchanged.
- Remove the now-duplicated `--force-cleanup` extra flag and rely on the pinned nix-darwin module to provide it.

## Why

`make apply` runs `darwin-rebuild switch`, which invokes `brew bundle` for Homebrew apps. With `homebrew.onActivation.upgrade = true`, outdated GUI casks such as Discord and Google Chrome can be upgraded during activation. Cask upgrades replace the `.app` bundle and can disturb macOS runtime permission state until apps or the system are restarted.

## Validation

- `nix eval --json '.#darwinConfigurations."j5ik2o-mac-studio".config.homebrew.onActivation.upgrade'` returns `false`.
- Built `.#darwinConfigurations."j5ik2o-mac-studio".system` successfully.
- Verified generated activation command includes `--no-upgrade --zap --force-cleanup --verbose`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Homebrew activation tweak; default cleanup stays `none` at the shared layer with host overrides unchanged, and the main effect is fewer automatic cask upgrades during apply.
> 
> **Overview**
> **`make apply` / `darwin-rebuild switch` no longer upgrades Homebrew packages during activation.** In `darwin/homebrew.nix`, `homebrew.onActivation.upgrade` is set from `true` to `false` so `brew bundle` runs with `--no-upgrade`, avoiding GUI cask upgrades (e.g. Discord, Chrome) that replace `.app` bundles and can unsettle macOS permission state until restart.
> 
> The module drops the custom `extraFlags` logic that conditionally appended `--force-cleanup` when cleanup was `uninstall` or `zap`, leaving only `--verbose` and relying on the pinned nix-darwin module for cleanup flags. The file header also stops taking `config` since that conditional no longer needs `config.homebrew.onActivation.cleanup`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ead7fee9e23163e8107c335decfaa541fe3955e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->