### PR TITLE
okite-ai 参照を削除

### DIFF
--- a/.agents/rules/avoiding-ambiguous-suffixes.md
+++ b/.agents/rules/avoiding-ambiguous-suffixes.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/avoiding-ambiguous-suffixes.md

--- a/.agents/rules/explain-skill-selection.md
+++ b/.agents/rules/explain-skill-selection.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/explain-skill-selection.md

--- a/.agents/rules/ignored-return-values.md
+++ b/.agents/rules/ignored-return-values.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/ignored-return-values.md

--- a/.agents/rules/learning-before-coding.md
+++ b/.agents/rules/learning-before-coding.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/learning-before-coding.md

--- a/.agents/rules/less-is-more.md
+++ b/.agents/rules/less-is-more.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/less-is-more.md

--- a/.agents/rules/prefer-immutability.md
+++ b/.agents/rules/prefer-immutability.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/prefer-immutability.md

--- a/.agents/rules/single-type-per-file.md
+++ b/.agents/rules/single-type-per-file.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/single-type-per-file.md

--- a/.agents/skills/aggregate-transaction-boundary
+++ b/.agents/skills/aggregate-transaction-boundary
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/aggregate-transaction-boundary

--- a/.agents/skills/auditcodex
+++ b/.agents/skills/auditcodex
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/auditcodex

--- a/.agents/skills/backward-compat-governance
+++ b/.agents/skills/backward-compat-governance
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/backward-compat-governance

--- a/.agents/skills/cqrs-aggregate-modeling
+++ b/.agents/skills/cqrs-aggregate-modeling
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/cqrs-aggregate-modeling

--- a/.agents/skills/cqrs-to-event-sourcing
+++ b/.agents/skills/cqrs-to-event-sourcing
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/cqrs-to-event-sourcing

--- a/.agents/skills/cqrs-tradeoffs
+++ b/.agents/skills/cqrs-tradeoffs
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/cqrs-tradeoffs

--- a/.agents/skills/creating-rules
+++ b/.agents/skills/creating-rules
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/creating-rules

--- a/.agents/skills/cross-aggregate-constraints
+++ b/.agents/skills/cross-aggregate-constraints
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/cross-aggregate-constraints

--- a/.agents/skills/deepresearch-readme
+++ b/.agents/skills/deepresearch-readme
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/deepresearch-readme

--- a/.agents/skills/domain-model-extractor
+++ b/.agents/skills/domain-model-extractor
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/domain-model-extractor

--- a/.agents/skills/error-classification
+++ b/.agents/skills/error-classification
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/error-classification

--- a/.agents/skills/intent-based-dedup
+++ b/.agents/skills/intent-based-dedup
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/intent-based-dedup

--- a/.agents/skills/migrate-skill-to-agent
+++ b/.agents/skills/migrate-skill-to-agent
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/migrate-skill-to-agent

--- a/.agents/skills/openspec-apply-change
+++ b/.agents/skills/openspec-apply-change
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/openspec-apply-change

--- a/.agents/skills/openspec-archive-change
+++ b/.agents/skills/openspec-archive-change
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/openspec-archive-change

--- a/.agents/skills/openspec-explore
+++ b/.agents/skills/openspec-explore
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/openspec-explore

--- a/.agents/skills/openspec-propose
+++ b/.agents/skills/openspec-propose
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/openspec-propose

--- a/.agents/skills/pekko-cqrs-es-implementation
+++ b/.agents/skills/pekko-cqrs-es-implementation
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/pekko-cqrs-es-implementation

--- a/.agents/skills/pr-green
+++ b/.agents/skills/pr-green
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/pr-green

--- a/.agents/skills/repository-design
+++ b/.agents/skills/repository-design
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/repository-design

--- a/.agents/skills/reviewing-skills
+++ b/.agents/skills/reviewing-skills
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/reviewing-skills

--- a/.agents/skills/when-to-wrap-primitives
+++ b/.agents/skills/when-to-wrap-primitives
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/when-to-wrap-primitives

--- a/.claude/rules/avoiding-ambiguous-suffixes.md
+++ b/.claude/rules/avoiding-ambiguous-suffixes.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/avoiding-ambiguous-suffixes.md

--- a/.claude/rules/explain-skill-selection.md
+++ b/.claude/rules/explain-skill-selection.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/explain-skill-selection.md

--- a/.claude/rules/ignored-return-values.md
+++ b/.claude/rules/ignored-return-values.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/ignored-return-values.md

--- a/.claude/rules/learning-before-coding.md
+++ b/.claude/rules/learning-before-coding.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/learning-before-coding.md

--- a/.claude/rules/less-is-more.md
+++ b/.claude/rules/less-is-more.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/less-is-more.md

--- a/.claude/rules/prefer-immutability.md
+++ b/.claude/rules/prefer-immutability.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/prefer-immutability.md

--- a/.claude/rules/single-type-per-file.md
+++ b/.claude/rules/single-type-per-file.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/single-type-per-file.md

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,0 @@
-../references/okite-ai/.claude/settings.json

--- a/.claude/skills/aggregate-transaction-boundary
+++ b/.claude/skills/aggregate-transaction-boundary
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/aggregate-transaction-boundary

--- a/.claude/skills/auditcodex
+++ b/.claude/skills/auditcodex
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/auditcodex

--- a/.claude/skills/backward-compat-governance
+++ b/.claude/skills/backward-compat-governance
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/backward-compat-governance

--- a/.claude/skills/cqrs-aggregate-modeling
+++ b/.claude/skills/cqrs-aggregate-modeling
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/cqrs-aggregate-modeling

--- a/.claude/skills/cqrs-to-event-sourcing
+++ b/.claude/skills/cqrs-to-event-sourcing
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/cqrs-to-event-sourcing

--- a/.claude/skills/cqrs-tradeoffs
+++ b/.claude/skills/cqrs-tradeoffs
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/cqrs-tradeoffs

--- a/.claude/skills/creating-rules
+++ b/.claude/skills/creating-rules
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/creating-rules

--- a/.claude/skills/cross-aggregate-constraints
+++ b/.claude/skills/cross-aggregate-constraints
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/cross-aggregate-constraints

--- a/.claude/skills/deepresearch-readme
+++ b/.claude/skills/deepresearch-readme
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/deepresearch-readme

--- a/.claude/skills/domain-model-extractor
+++ b/.claude/skills/domain-model-extractor
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/domain-model-extractor

--- a/.claude/skills/error-classification
+++ b/.claude/skills/error-classification
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/error-classification

--- a/.claude/skills/intent-based-dedup
+++ b/.claude/skills/intent-based-dedup
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/intent-based-dedup

--- a/.claude/skills/migrate-skill-to-agent
+++ b/.claude/skills/migrate-skill-to-agent
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/migrate-skill-to-agent

--- a/.claude/skills/openspec-apply-change
+++ b/.claude/skills/openspec-apply-change
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/openspec-apply-change

--- a/.claude/skills/openspec-archive-change
+++ b/.claude/skills/openspec-archive-change
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/openspec-archive-change

--- a/.claude/skills/openspec-explore
+++ b/.claude/skills/openspec-explore
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/openspec-explore

--- a/.claude/skills/openspec-propose
+++ b/.claude/skills/openspec-propose
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/openspec-propose

--- a/.claude/skills/pekko-cqrs-es-implementation
+++ b/.claude/skills/pekko-cqrs-es-implementation
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/pekko-cqrs-es-implementation

--- a/.claude/skills/pr-green
+++ b/.claude/skills/pr-green
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/pr-green

--- a/.claude/skills/repository-design
+++ b/.claude/skills/repository-design
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/repository-design

--- a/.claude/skills/reviewing-skills
+++ b/.claude/skills/reviewing-skills
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/reviewing-skills

--- a/.claude/skills/when-to-wrap-primitives
+++ b/.claude/skills/when-to-wrap-primitives
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/when-to-wrap-primitives

--- a/.cursor/rules/avoiding-ambiguous-suffixes.md
+++ b/.cursor/rules/avoiding-ambiguous-suffixes.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/avoiding-ambiguous-suffixes.md

--- a/.cursor/rules/explain-skill-selection.md
+++ b/.cursor/rules/explain-skill-selection.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/explain-skill-selection.md

--- a/.cursor/rules/ignored-return-values.md
+++ b/.cursor/rules/ignored-return-values.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/ignored-return-values.md

--- a/.cursor/rules/learning-before-coding.md
+++ b/.cursor/rules/learning-before-coding.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/learning-before-coding.md

--- a/.cursor/rules/less-is-more.md
+++ b/.cursor/rules/less-is-more.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/less-is-more.md

--- a/.cursor/rules/prefer-immutability.md
+++ b/.cursor/rules/prefer-immutability.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/prefer-immutability.md

--- a/.cursor/rules/single-type-per-file.md
+++ b/.cursor/rules/single-type-per-file.md
@@ -1,1 +1,0 @@
-../../references/okite-ai/.agents/rules/single-type-per-file.md

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,1 +1,0 @@
-../references/okite-ai/.gemini/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,10 @@ result
 
 /.kiro/
 /openspec/
+/references/okite-ai/
 
 # API Keys and Tokens (security)
 *_api_key.sh
 *.env
 .anthropic_api_key.sh
 .glm_api_key.sh
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "references/okite-ai"]
-	path = references/okite-ai
-	url = git@github.com:j5ik2o/okite-ai.git

--- a/scripts/generate-agents-md.sh
+++ b/scripts/generate-agents-md.sh
@@ -1,1 +1,0 @@
-../references/okite-ai/scripts/generate-agents-md.sh


### PR DESCRIPTION
## 概要

- `references/okite-ai` サブモジュールの登録を削除しました。
- `okite-ai` に向いていた `.agents` / `.claude` / `.cursor` / `.gemini` / `scripts` の symlink を削除しました。
- ローカル退避用に `references/okite-ai/` を `.gitignore` に追加しました。

## 背景

`okite-ai` を今後この dotfiles から利用しない方針にするため、Git 管理上の依存と参照を外します。ローカルの `references/okite-ai/` 実体は未コミット変更保護のため削除対象にせず、ignore 対象として残せるようにしています。

## 検証

- `git diff --check origin/main..HEAD`
- `git submodule status` が空であること
- `rg "okite-ai|references/okite|okite"` で `.gitignore` の退避パターン以外に参照がないこと

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and symlink cleanup only; no runtime application or security-sensitive logic changes.
> 
> **Overview**
> This PR **removes the `okite-ai` dependency** from this dotfiles repo so it is no longer managed or wired in via Git.
> 
> **`.gitmodules`** is deleted, unregistering the `references/okite-ai` submodule. Symlinks under **`.agents`**, **`.claude`**, **`.cursor`**, **`.gemini`**, and **`scripts`** that pointed at `references/okite-ai` are removed, so agent rules, skills, and settings are no longer pulled from that external tree.
> 
> **`.gitignore`** gains **`/references/okite-ai/`** so a local copy of the submodule directory can stay on disk without being committed after the submodule is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1904bb6b397966ce4c80d0116076430e54f0a3ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->